### PR TITLE
BUG-805: Poistettu ammatilliset kaksoistutkinnot lukion hakurajaimesta.

### DIFF
--- a/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/converter/KoulutusLOSToSolrInputDocment.java
+++ b/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/converter/KoulutusLOSToSolrInputDocment.java
@@ -570,9 +570,6 @@ public class KoulutusLOSToSolrInputDocment implements Converter<KoulutusLOS, Lis
             } else if (los.getEducationType().equals(SolrConstants.ED_TYPE_AMMATILLINEN)) {
                 doc.addField(LearningOpportunity.EDUCATION_TYPE, SolrUtil.SolrConstants.ED_TYPE_AMMATILLISET);
                 doc.addField(LearningOpportunity.EDUCATION_TYPE, SolrUtil.SolrConstants.ED_TYPE_AMMATILLINEN);
-                if (isKaksoistutkinto) {
-                    doc.addField(LearningOpportunity.EDUCATION_TYPE, SolrUtil.SolrConstants.ED_TYPE_LUKIO);
-                }
             } else if (los.getEducationType().equals(SolrConstants.ED_TYPE_AIKUISLUKIO)) {
                 doc.addField(LearningOpportunity.EDUCATION_TYPE, SolrUtil.SolrConstants.ED_TYPE_LUKIO);
                 doc.addField(LearningOpportunity.EDUCATION_TYPE, SolrUtil.SolrConstants.ED_TYPE_AIKUISLUKIO);


### PR DESCRIPTION
Lukiokoulutusten joukossa ei saa näkyä ammatillista koulutusta edes kaksoistutkintona.
