### PR TITLE
BUG-1597: Tutkintosivun otsikon koulutuskoodia ei pidä lukea komolta …

### DIFF
--- a/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/service/builder/impl/LOSObjectCreator.java
+++ b/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/service/builder/impl/LOSObjectCreator.java
@@ -1341,13 +1341,13 @@ public class LOSObjectCreator extends ObjectCreator {
 
     }
 
-    public TutkintoLOS createTutkintoLOS(String komoOid, String providerOid, String year, String season, Code prerequisite) throws KoodistoException, TarjontaParseException {
+    public TutkintoLOS createTutkintoLOS(String komoOid, String providerOid, String year, String season, Code prerequisite, I18nText koulutuskoodi) throws KoodistoException, TarjontaParseException {
         ResultV1RDTO<KomoV1RDTO> v1KomoRaw = tarjontaRawService.getV1Komo(komoOid);
         KomoV1RDTO komo = v1KomoRaw.getResult();
-        return createTutkintoLOS(komo, providerOid, year, season, prerequisite);
+        return createTutkintoLOS(komo, providerOid, year, season, prerequisite, koulutuskoodi);
     }
 
-    private TutkintoLOS createTutkintoLOS(KomoV1RDTO komo, String providerOid, String year, String season, Code prerequisite) throws KoodistoException, TarjontaParseException {
+    private TutkintoLOS createTutkintoLOS(KomoV1RDTO komo, String providerOid, String year, String season, Code prerequisite, I18nText koulutuskoodi) throws KoodistoException, TarjontaParseException {
         LOG.debug("Creating provider specific parent (" + providerOid + ") LOS from komo: " + komo.getOid());
         TutkintoLOS tutkintoLOS = new TutkintoLOS();
         tutkintoLOS.setType(TarjontaConstants.TYPE_PARENT);
@@ -1372,7 +1372,7 @@ public class LOSObjectCreator extends ObjectCreator {
             prerequisiteString = prerequisite.getValue().equals("ER") ? "ER" : "PKYO";
         }
         tutkintoLOS.setId(CreatorUtil.resolveLOSId(komo.getOid(), providerOid, year, season, prerequisiteString));
-        tutkintoLOS.setName(getI18nTextEnriched(komo.getKoulutuskoodi()));
+        tutkintoLOS.setName(koulutuskoodi);
         tutkintoLOS.setShortTitle(getI18nTextEnriched(komo.getKoulutuskoodi()));
         NimiV1RDTO goals = komo.getKuvausKomo().get(KomoTeksti.TAVOITTEET);
         if (goals != null) {

--- a/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/service/impl/TarjontaServiceImpl.java
+++ b/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/service/impl/TarjontaServiceImpl.java
@@ -890,7 +890,7 @@ public class TarjontaServiceImpl implements TarjontaService {
             }
             TutkintoLOS tutkinto = getAlreadyProcessedTutkinto(tutkintokey);
             if (tutkinto == null) {
-                tutkinto = creator.createTutkintoLOS(parentoid, providerOid, "" + koulutus.getStartYear(), koulutus.getStartSeason().get("fi"), koulutus.getKoulutusPrerequisite());
+                tutkinto = creator.createTutkintoLOS(parentoid, providerOid, "" + koulutus.getStartYear(), koulutus.getStartSeason().get("fi"), koulutus.getKoulutusPrerequisite(), koulutus.getKoulutuskoodi());
             }
             if (koulutus.isOsaamisalaton()) {
                 koulutus.setSiblings(new ArrayList<KoulutusLOS>());


### PR DESCRIPTION
…vaan koulutukselta.

Versioitua koulutuskoodia ei versioimattomalla komolla voi muuttaa tarjonnassa, koska muutokset propagoituisivat vanhoihin komon koulutuksiin.
Siispä luetaan ajantasainen koulutuskoodi koulutukselta.