### PR TITLE
BUG-2055 Fix koodisto client url encoding

### DIFF
--- a/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/configuration/WebServices.java
+++ b/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/configuration/WebServices.java
@@ -31,6 +31,6 @@ public class WebServices {
 
     @Bean(name="koodistoClient")
     public KoodistoClient getKoodistoClient(OphProperties urlConfiguration) {
-        return new CachingKoodistoClient(urlConfiguration.url("koodisto-service.base")).setCallerId(HttpClient.CALLER_ID);
+        return new CachingKoodistoClient(urlConfiguration.url("url-virkailija")).setCallerId(HttpClient.CALLER_ID);
     }
 }

--- a/koulutusinformaatio-service/src/test/java/fi/vm/sade/koulutusinformaatio/service/impl/KoodistoServiceImplTest.java
+++ b/koulutusinformaatio-service/src/test/java/fi/vm/sade/koulutusinformaatio/service/impl/KoodistoServiceImplTest.java
@@ -20,6 +20,7 @@ package fi.vm.sade.koulutusinformaatio.service.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,11 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
+import fi.vm.sade.javautils.httpclient.OphHttpRequest;
+import fi.vm.sade.javautils.httpclient.OphRequestParameters;
+import fi.vm.sade.koodisto.util.CachingKoodistoClient;
+import fi.vm.sade.koodisto.util.KoodiServiceSearchCriteriaBuilder;
+import fi.vm.sade.koulutusinformaatio.domain.CodeUriAndVersion;
 import fi.vm.sade.koulutusinformaatio.service.impl.metrics.RollingAverageLogger;
 import org.junit.Before;
 import org.junit.Test;
@@ -196,6 +202,22 @@ public class KoodistoServiceImplTest {
         assertEquals("kuvaus_fi", result.get(1).getDescription().getTranslations().get("fi"));
         assertEquals("kuvaus_sv", result.get(1).getDescription().getTranslations().get("sv"));
     }
+
+    @Test
+    public void test() throws KoodistoException {
+        KoodistoClient client = new CachingKoodistoClient("");
+        CodeUriAndVersion codeUriAndVersion = new CodeUriAndVersion("koodi_uri", 1);
+        SearchKoodisCriteriaType sc = KoodiServiceSearchCriteriaBuilder.latestKoodisByUris(codeUriAndVersion.getUri());
+        OphHttpRequest request = client.buildSearchKoodiRequest(sc);
+        OphRequestParameters.MultiValueMap<String, String> params = request.getRequestParameters().params;
+        for (List<String> paramValues : params.values()) {
+                for (String paramValue : paramValues) {
+                    boolean bool = paramValue.contains("[") || paramValue.contains("]");
+                    assertFalse(bool);
+                }
+        }
+    }
+
 
 
 }

--- a/koulutusinformaatio-service/src/test/java/fi/vm/sade/koulutusinformaatio/service/impl/KoodistoServiceImplTest.java
+++ b/koulutusinformaatio-service/src/test/java/fi/vm/sade/koulutusinformaatio/service/impl/KoodistoServiceImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import fi.vm.sade.javautils.httpclient.OphHttpRequest;
 import fi.vm.sade.javautils.httpclient.OphRequestParameters;
@@ -204,7 +205,7 @@ public class KoodistoServiceImplTest {
     }
 
     @Test
-    public void test() throws KoodistoException {
+    public void listsAreCorrectlyEncoded() {
         KoodistoClient client = new CachingKoodistoClient("");
         CodeUriAndVersion codeUriAndVersion = new CodeUriAndVersion("koodi_uri", 1);
         SearchKoodisCriteriaType sc = KoodiServiceSearchCriteriaBuilder.latestKoodisByUris(codeUriAndVersion.getUri());
@@ -212,12 +213,21 @@ public class KoodistoServiceImplTest {
         OphRequestParameters.MultiValueMap<String, String> params = request.getRequestParameters().params;
         for (List<String> paramValues : params.values()) {
                 for (String paramValue : paramValues) {
-                    boolean bool = paramValue.contains("[") || paramValue.contains("]");
-                    assertFalse(bool);
+                    boolean containsBrackets = paramValue.contains("[") || paramValue.contains("]");
+                    assertFalse(containsBrackets);
                 }
         }
     }
 
-
+    @Test
+    public void nullAndEmptyParamsAreExcluded() {
+        KoodistoClient client = new CachingKoodistoClient("");
+        CodeUriAndVersion codeUriAndVersion = new CodeUriAndVersion("koodi_uri", 1);
+        SearchKoodisCriteriaType sc = KoodiServiceSearchCriteriaBuilder.latestKoodisByUris(codeUriAndVersion.getUri());
+        OphHttpRequest request = client.buildSearchKoodiRequest(sc);
+        Set<String> keys = request.getRequestParameters().params.keySet();
+        boolean containsKeysThatWereNotSpecified = keys.contains("validAt") || keys.contains("koodiTilas");
+        assertFalse(containsKeysThatWereNotSpecified);
+    }
 
 }

--- a/koulutusinformaatio-service/src/test/java/fi/vm/sade/koulutusinformaatio/service/impl/KoodistoServiceImplTest.java
+++ b/koulutusinformaatio-service/src/test/java/fi/vm/sade/koulutusinformaatio/service/impl/KoodistoServiceImplTest.java
@@ -20,6 +20,7 @@ package fi.vm.sade.koulutusinformaatio.service.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -228,6 +229,16 @@ public class KoodistoServiceImplTest {
         Set<String> keys = request.getRequestParameters().params.keySet();
         boolean containsKeysThatWereNotSpecified = keys.contains("validAt") || keys.contains("koodiTilas");
         assertFalse(containsKeysThatWereNotSpecified);
+    }
+
+    @Test
+    public void versionParamIsIncluded() {
+        KoodistoClient client = new CachingKoodistoClient("");
+        SearchKoodisCriteriaType sc = KoodiServiceSearchCriteriaBuilder.koodiByUriAndVersion("koodi_uri", 1);
+        OphHttpRequest request = client.buildSearchKoodiRequest(sc);
+        Set<String> keys = request.getRequestParameters().params.keySet();
+        boolean containsVersionParam = keys.contains("koodiVersio");
+        assertTrue(containsVersionParam);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <jackson2.version>2.9.7</jackson2.version>
         <morphia.version>1.3.2</morphia.version>
         <oph.organisaatio.version>2018-6-SNAPSHOT</oph.organisaatio.version>
-        <oph.koodisto.version>2019-08-SNAPSHOT</oph.koodisto.version>
+        <oph.koodisto.version>2019-09-SNAPSHOT</oph.koodisto.version>
         <oph.tarjonta.version>2017-40-SNAPSHOT</oph.tarjonta.version>
         <java-utils-httpclient.version>0.3.0-SNAPSHOT</java-utils-httpclient.version>
         <javax.mail.version>1.4.7</javax.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <jackson2.version>2.9.7</jackson2.version>
         <morphia.version>1.3.2</morphia.version>
         <oph.organisaatio.version>2018-6-SNAPSHOT</oph.organisaatio.version>
-        <oph.koodisto.version>2019-06-SNAPSHOT</oph.koodisto.version>
+        <oph.koodisto.version>2019-08-SNAPSHOT</oph.koodisto.version>
         <oph.tarjonta.version>2017-40-SNAPSHOT</oph.tarjonta.version>
         <java-utils-httpclient.version>0.3.0-SNAPSHOT</java-utils-httpclient.version>
         <javax.mail.version>1.4.7</javax.mail.version>


### PR DESCRIPTION
Confirm with test that url encoding is broken in CachingKoodistoClient.

Use new 2019-09 version of koodisto-api to fix it.

See https://github.com/Opetushallitus/koodisto/pull/47