### PR TITLE
BUG-2193: Opintojen rakenteen kuva ei näy KI:ssä

### DIFF
--- a/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/service/impl/TarjontaServiceImpl.java
+++ b/koulutusinformaatio-service/src/main/java/fi/vm/sade/koulutusinformaatio/service/impl/TarjontaServiceImpl.java
@@ -59,7 +59,7 @@ import java.util.*;
 public class TarjontaServiceImpl implements TarjontaService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TarjontaServiceImpl.class);
-    private static final int MAX_IMAGE_WIDTH = 800;
+    private static final int MAX_IMAGE_WIDTH = 1200;
 
     private KoodistoService koodistoService;
     private ProviderService providerService;


### PR DESCRIPTION
Rakenteen kuvan maksimileveys nostettu 1200 pikseliin, jotta kuvien kokoa ei tarvitsisi ohjelmallisesti muokata (käytössä epäluotettava kirjasto joka ei vaikuta olevan kovin helposti korjattavissa).